### PR TITLE
demote typescript to devDependency

### DIFF
--- a/compiled/helpers.js
+++ b/compiled/helpers.js
@@ -59,7 +59,6 @@ function getAllCodeowners(fileContents) {
         })
             .map((line) => {
             const [_path, ...owners] = line.trim().split(/\s+/);
-            console.log(_path, owners);
             return owners;
         })
             .flat();

--- a/package.json
+++ b/package.json
@@ -77,18 +77,18 @@
     "@types/jest": "^29.0.0",
     "@typescript-eslint/eslint-plugin": "^5.36.1",
     "@typescript-eslint/parser": "^5.36.1",
+    "@vercel/ncc": "^0.34.0",
     "dotenv-cli": "^6.0.0",
     "eslint": "^8.23.0",
     "eslint-config-prettier": "8.5.0",
     "eslint-plugin-jest": "^27.0.1",
     "jest": "^29.0.1",
     "prettier": "2.7.1",
-    "ts-jest": "^28.0.8"
+    "ts-jest": "^28.0.8",
+    "typescript": "^4.8.2"
   },
   "dependencies": {
     "@actions/core": "^1.9.1",
-    "@actions/github": "^5.0.3",
-    "@vercel/ncc": "^0.34.0",
-    "typescript": "^4.8.2"
+    "@actions/github": "^5.0.3"
   }
 }


### PR DESCRIPTION
The `@vercel/ncc` and `typescript` dependencies were listed as direct dependencies, but these are only required for development (not production). They can therefore be made `devDependencies` 🎉 .

Additionally I ran `yarn compile && yarn package`, and detected some errant debugging code in the compile artifact. The template actions use a workflow called [check-dist.yaml](https://github.com/actions/typescript-action/blob/main/.github/workflows/check-dist.yml) to keep these in sync automatically.


# Related
 - Template JavaScript action does it - https://github.com/actions/javascript-action/blob/fc287e4e8e4a24e4d948c8d44fb70763f4f3e3e2/package.json#L31
- Template TypeScript action does it too - https://github.com/actions/typescript-action/blob/bbdc4b1cfa051c37cf6e267cd54cb4f4f89ffc34/package.json#L41
